### PR TITLE
lsm6dso: Add FIFO and LPF capabilities

### DIFF
--- a/drivers/sensor/lsm6dso/Kconfig
+++ b/drivers/sensor/lsm6dso/Kconfig
@@ -85,4 +85,7 @@ config LSM6DSO_EXT_LPS22HB
 
 endif # LSM6DSO_SENSORHUB
 
+config LSM6DSO_ENABLE_FIFO
+	bool "Use FIFO MODE"
+
 endif # LSM6DSO

--- a/drivers/sensor/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/lsm6dso/lsm6dso.c
@@ -19,6 +19,7 @@
 #include <sys/__assert.h>
 #include <logging/log.h>
 
+#include <drivers/sensor/lsm6dso.h>
 #include "lsm6dso.h"
 
 LOG_MODULE_REGISTER(LSM6DSO, CONFIG_SENSOR_LOG_LEVEL);
@@ -192,17 +193,29 @@ static int lsm6dso_accel_config(const struct device *dev,
 				enum sensor_attribute attr,
 				const struct sensor_value *val)
 {
+	const struct lsm6dso_config *cfg = dev->config;
+	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
+	int ret = 0;
+
 	switch (attr) {
 	case SENSOR_ATTR_FULL_SCALE:
-		return lsm6dso_accel_range_set(dev, sensor_ms2_to_g(val));
+		ret = lsm6dso_accel_range_set(dev, sensor_ms2_to_g(val));
+		break;
 	case SENSOR_ATTR_SAMPLING_FREQUENCY:
-		return lsm6dso_accel_odr_set(dev, val->val1);
+		ret = lsm6dso_accel_odr_set(dev, val->val1);
+		break;
+	case SENSOR_ATTR_LPF_FREQ:
+		/* En-/disable Accel LPF2 */
+		ret = lsm6dso_xl_filter_lp2_set(ctx, val->val1);
+		/* Configure Accel LPF2 cut-off frequency */
+		ret |= lsm6dso_xl_hp_path_on_out_set(ctx, val->val2);
+		break;
 	default:
 		LOG_DBG("Accel attribute not supported.");
-		return -ENOTSUP;
+		ret = -ENOTSUP;
 	}
 
-	return 0;
+	return ret;
 }
 
 static int lsm6dso_gyro_odr_set(const struct device *dev, uint16_t freq)
@@ -246,17 +259,29 @@ static int lsm6dso_gyro_config(const struct device *dev,
 			       enum sensor_attribute attr,
 			       const struct sensor_value *val)
 {
+	const struct lsm6dso_config *cfg = dev->config;
+	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
+	int ret = 0;
+
 	switch (attr) {
 	case SENSOR_ATTR_FULL_SCALE:
-		return lsm6dso_gyro_range_set(dev, sensor_rad_to_degrees(val));
+		ret = lsm6dso_gyro_range_set(dev, sensor_rad_to_degrees(val));
+		break;
 	case SENSOR_ATTR_SAMPLING_FREQUENCY:
-		return lsm6dso_gyro_odr_set(dev, val->val1);
+		ret = lsm6dso_gyro_odr_set(dev, val->val1);
+		break;
+	case SENSOR_ATTR_LPF_FREQ:
+		/* Enable Gyro LPF 1 */
+		ret = lsm6dso_gy_filter_lp1_set(ctx, val->val1);
+		/* Configure Gyro LPF1 cut-off frequency */
+		ret |= lsm6dso_gy_lp1_bandwidth_set(ctx, val->val2);
+		break;
 	default:
 		LOG_DBG("Gyro attribute not supported.");
-		return -ENOTSUP;
+		ret = -ENOTSUP;
 	}
 
-	return 0;
+	return ret;
 }
 
 static int lsm6dso_attr_set(const struct device *dev,
@@ -330,6 +355,46 @@ static int lsm6dso_sample_fetch_gyro(const struct device *dev)
 	return 0;
 }
 
+#if defined(CONFIG_LSM6DSO_ENABLE_FIFO)
+static int lsm6dso_sample_fetch_fifo(const struct device *dev)
+{
+	const struct lsm6dso_config *cfg = dev->config;
+	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
+	struct lsm6dso_data *data = dev->data;
+	uint8_t buff[6];
+	uint16_t num_data_fifo;
+	lsm6dso_fifo_tag_t data_tag;
+
+	lsm6dso_fifo_data_level_get(ctx, &num_data_fifo);
+	for (int i = 0; i < num_data_fifo; i++) {
+		lsm6dso_fifo_sensor_tag_get(ctx, &data_tag);
+		if (lsm6dso_fifo_out_raw_get(ctx, buff) < 0) {
+			LOG_DBG("Failed to read sample");
+			return -EIO;
+		}
+		if (data_tag == LSM6DSO_GYRO_NC_TAG) {
+			data->gyro[0] = (int16_t)buff[1];
+			data->gyro[0] = (data->gyro[0] * 256) + (int16_t)buff[0];
+			data->gyro[1] = (int16_t)buff[3];
+			data->gyro[1] = (data->gyro[1] * 256) + (int16_t)buff[2];
+			data->gyro[2] = (int16_t)buff[5];
+			data->gyro[2] = (data->gyro[2] * 256) + (int16_t)buff[4];
+		} else if (data_tag == LSM6DSO_XL_NC_TAG) {
+			data->acc[0] = (int16_t)buff[1];
+			data->acc[0] = (data->acc[0] * 256) + (int16_t)buff[0];
+			data->acc[1] = (int16_t)buff[3];
+			data->acc[1] = (data->acc[1] * 256) + (int16_t)buff[2];
+			data->acc[2] = (int16_t)buff[5];
+			data->acc[2] = (data->acc[2] * 256) + (int16_t)buff[4];
+		} else {
+			LOG_WRN("Unhandled data: tag=%d", data_tag);
+		}
+	}
+
+	return 0;
+}
+#endif
+
 #if defined(CONFIG_LSM6DSO_ENABLE_TEMP)
 static int lsm6dso_sample_fetch_temp(const struct device *dev)
 {
@@ -381,8 +446,12 @@ static int lsm6dso_sample_fetch(const struct device *dev,
 		break;
 #endif
 	case SENSOR_CHAN_ALL:
+#if defined(CONFIG_LSM6DSO_ENABLE_FIFO)
+		lsm6dso_sample_fetch_fifo(dev);
+#else
 		lsm6dso_sample_fetch_accel(dev);
 		lsm6dso_sample_fetch_gyro(dev);
+#endif
 #if defined(CONFIG_LSM6DSO_ENABLE_TEMP)
 		lsm6dso_sample_fetch_temp(dev);
 #endif
@@ -803,11 +872,34 @@ static int lsm6dso_init_chip(const struct device *dev)
 		return -EIO;
 	}
 
+#if defined(CONFIG_LSM6DSO_ENABLE_FIFO)
+	LOG_DBG("Setting FIFO mode");
+	if (lsm6dso_fifo_mode_set(ctx, LSM6DSO_FIFO_MODE) < 0) {
+		LOG_DBG("failed to set FIFO mode");
+		return -EIO;
+	}
+
+	if (lsm6dso_batch_counter_threshold_set(ctx, cfg->batch_cnt_thr)) {
+		LOG_DBG("Setting FIFO batch count threshold Failed");
+		return -EIO;
+	}
+
+	if (lsm6dso_fifo_xl_batch_set(ctx, cfg->accel_bdr)) {
+		LOG_DBG("Enable Accel FIFO batch mode Failed");
+		return -EIO;
+	}
+
+	if (lsm6dso_fifo_gy_batch_set(ctx, cfg->gyro_bdr)) {
+		LOG_DBG("Enable Gyro FIFO batch mode Failed");
+		return -EIO;
+	}
+#else
 	/* Set FIFO bypass mode */
 	if (lsm6dso_fifo_mode_set(ctx, LSM6DSO_BYPASS_MODE) < 0) {
 		LOG_DBG("failed to set FIFO mode");
 		return -EIO;
 	}
+#endif
 
 	if (lsm6dso_block_data_update_set(ctx, 1) < 0) {
 		LOG_DBG("failed to set BDU mode");
@@ -878,11 +970,20 @@ static int lsm6dso_init(const struct device *dev)
 #ifdef CONFIG_LSM6DSO_TRIGGER
 #define LSM6DSO_CFG_IRQ(inst)						\
 	.trig_enabled = true,						\
-	.gpio_drdy = GPIO_DT_SPEC_INST_GET(inst, irq_gpios),		\
-	.int_pin = DT_INST_PROP(inst, int_pin)
+	.gpio_intr = GPIO_DT_SPEC_INST_GET(inst, irq_gpios),		\
+	.int_pin = DT_INST_PROP(inst, int_pin),
 #else
 #define LSM6DSO_CFG_IRQ(inst)
 #endif /* CONFIG_LSM6DSO_TRIGGER */
+
+#ifdef CONFIG_LSM6DSO_ENABLE_FIFO
+#define LSM6DSO_CFG_FIFO(inst)						\
+	.batch_cnt_thr = DT_INST_PROP(inst, batch_cnt_thr),		\
+	.accel_bdr = DT_INST_PROP(inst, accel_bdr),			\
+	.gyro_bdr = DT_INST_PROP(inst, gyro_bdr),
+#else
+#define LSM6DSO_CFG_FIFO(inst)
+#endif /* CONFIG_LSM6DSO_ENABLE_FIFO */
 
 #define LSM6DSO_SPI_OP  (SPI_WORD_SET(8) |				\
 			 SPI_OP_MODE_MASTER |				\
@@ -913,6 +1014,7 @@ static int lsm6dso_init(const struct device *dev)
 		.gyro_range = DT_INST_PROP(inst, gyro_range),		\
 		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, irq_gpios),	\
 			(LSM6DSO_CFG_IRQ(inst)), ())			\
+		LSM6DSO_CFG_FIFO(inst)					\
 	}
 
 /*
@@ -940,6 +1042,7 @@ static int lsm6dso_init(const struct device *dev)
 		.gyro_range = DT_INST_PROP(inst, gyro_range),		\
 		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, irq_gpios),	\
 			(LSM6DSO_CFG_IRQ(inst)), ())			\
+		LSM6DSO_CFG_FIFO(inst)					\
 	}
 
 /*

--- a/drivers/sensor/lsm6dso/lsm6dso.h
+++ b/drivers/sensor/lsm6dso/lsm6dso.h
@@ -57,10 +57,15 @@ struct lsm6dso_config {
 	uint8_t gyro_odr;
 	uint8_t gyro_range;
 #ifdef CONFIG_LSM6DSO_TRIGGER
-	const struct gpio_dt_spec gpio_drdy;
+	const struct gpio_dt_spec gpio_intr;
 	uint8_t int_pin;
 	bool trig_enabled;
 #endif /* CONFIG_LSM6DSO_TRIGGER */
+#ifdef CONFIG_LSM6DSO_ENABLE_FIFO
+	uint16_t batch_cnt_thr;
+	uint8_t accel_bdr;
+	uint8_t gyro_bdr;
+#endif /* CONFIG_LSM6DSO_ENABLE_FIFO */
 };
 
 union samples {
@@ -106,6 +111,9 @@ struct lsm6dso_data {
 	sensor_trigger_handler_t handler_drdy_acc;
 	sensor_trigger_handler_t handler_drdy_gyr;
 	sensor_trigger_handler_t handler_drdy_temp;
+#if defined(CONFIG_LSM6DSO_ENABLE_FIFO)
+	sensor_trigger_handler_t handler_fifo_bdr_cnt;
+#endif
 
 #if defined(CONFIG_LSM6DSO_TRIGGER_OWN_THREAD)
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_LSM6DSO_THREAD_STACK_SIZE);

--- a/drivers/sensor/lsm6dso/lsm6dso_trigger.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_trigger.c
@@ -15,6 +15,7 @@
 #include <drivers/gpio.h>
 #include <logging/log.h>
 
+#include <drivers/sensor/lsm6dso.h>
 #include "lsm6dso.h"
 
 LOG_MODULE_DECLARE(LSM6DSO, CONFIG_SENSOR_LOG_LEVEL);
@@ -119,6 +120,37 @@ static int lsm6dso_enable_g_int(const struct device *dev, int enable)
 	}
 }
 
+#if defined(CONFIG_LSM6DSO_ENABLE_FIFO)
+/**
+ * lsm6dso_enable_fifo_bdr_cnt_int - BDR counter threshold enable selected
+ * int pin to generate interrupt
+ */
+static int lsm6dso_enable_fifo_bdr_cnt_int(const struct device *dev, int enable)
+{
+	const struct lsm6dso_config *cfg = dev->config;
+	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
+
+	/* set interrupt */
+	if (cfg->int_pin == 1) {
+		lsm6dso_int1_ctrl_t int1_ctrl;
+
+		lsm6dso_read_reg(ctx, LSM6DSO_INT1_CTRL,
+				 (uint8_t *)&int1_ctrl, 1);
+		int1_ctrl.int1_cnt_bdr = enable;
+		return lsm6dso_write_reg(ctx, LSM6DSO_INT1_CTRL,
+					 (uint8_t *)&int1_ctrl, 1);
+	} else {
+		lsm6dso_int2_ctrl_t int2_ctrl;
+
+		lsm6dso_read_reg(ctx, LSM6DSO_INT2_CTRL,
+				 (uint8_t *)&int2_ctrl, 1);
+		int2_ctrl.int2_cnt_bdr = enable;
+		return lsm6dso_write_reg(ctx, LSM6DSO_INT2_CTRL,
+					 (uint8_t *)&int2_ctrl, 1);
+	}
+}
+#endif
+
 /**
  * lsm6dso_trigger_set - link external trigger to event data ready
  */
@@ -128,6 +160,9 @@ int lsm6dso_trigger_set(const struct device *dev,
 {
 	const struct lsm6dso_config *cfg = dev->config;
 	struct lsm6dso_data *lsm6dso = dev->data;
+#if defined(CONFIG_LSM6DSO_ENABLE_FIFO)
+	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
+#endif
 
 	if (!cfg->trig_enabled) {
 		LOG_ERR("trigger_set op not supported");
@@ -135,19 +170,57 @@ int lsm6dso_trigger_set(const struct device *dev,
 	}
 
 	if (trig->chan == SENSOR_CHAN_ACCEL_XYZ) {
-		lsm6dso->handler_drdy_acc = handler;
-		if (handler) {
-			return lsm6dso_enable_xl_int(dev, LSM6DSO_EN_BIT);
-		} else {
-			return lsm6dso_enable_xl_int(dev, LSM6DSO_DIS_BIT);
+		if (trig->type == SENSOR_TRIG_DATA_READY) {
+			lsm6dso->handler_drdy_acc = handler;
+			if (handler) {
+				return lsm6dso_enable_xl_int(dev, LSM6DSO_EN_BIT);
+			} else {
+				return lsm6dso_enable_xl_int(dev, LSM6DSO_DIS_BIT);
+			}
 		}
+#if defined(CONFIG_LSM6DSO_ENABLE_FIFO)
+		else if ((int16_t)trig->type == SENSOR_TRIG_LSM6DSO_CNT_BDR) {
+			/* Clear FIFO data */
+			lsm6dso_fifo_mode_set(ctx, LSM6DSO_BYPASS_MODE);
+			lsm6dso_fifo_mode_set(ctx, LSM6DSO_FIFO_MODE);
+			/* FIFO BDR Counter threshold interrupt */
+			lsm6dso->handler_fifo_bdr_cnt = handler;
+			if (handler) {
+				if (lsm6dso_fifo_cnt_event_batch_set(ctx, LSM6DSO_XL_BATCH_EVENT)) {
+					return -EIO;
+				}
+				return lsm6dso_enable_fifo_bdr_cnt_int(dev, LSM6DSO_EN_BIT);
+			} else {
+				return lsm6dso_enable_fifo_bdr_cnt_int(dev, LSM6DSO_DIS_BIT);
+			}
+		}
+#endif
 	} else if (trig->chan == SENSOR_CHAN_GYRO_XYZ) {
-		lsm6dso->handler_drdy_gyr = handler;
-		if (handler) {
-			return lsm6dso_enable_g_int(dev, LSM6DSO_EN_BIT);
-		} else {
-			return lsm6dso_enable_g_int(dev, LSM6DSO_DIS_BIT);
+		if (trig->type == SENSOR_TRIG_DATA_READY) {
+			lsm6dso->handler_drdy_gyr = handler;
+			if (handler) {
+				return lsm6dso_enable_g_int(dev, LSM6DSO_EN_BIT);
+			} else {
+				return lsm6dso_enable_g_int(dev, LSM6DSO_DIS_BIT);
+			}
 		}
+#if defined(CONFIG_LSM6DSO_ENABLE_FIFO)
+		else if ((int16_t)trig->type == SENSOR_TRIG_LSM6DSO_CNT_BDR) {
+			/* Clear FIFO data */
+			lsm6dso_fifo_mode_set(ctx, LSM6DSO_BYPASS_MODE);
+			lsm6dso_fifo_mode_set(ctx, LSM6DSO_FIFO_MODE);
+			/* FIFO Threshold interrupt */
+			lsm6dso->handler_fifo_bdr_cnt = handler;
+			if (handler) {
+				if (lsm6dso_fifo_cnt_event_batch_set(ctx, LSM6DSO_GYRO_BATCH_EVENT)) {
+					return -EIO;
+				}
+				return lsm6dso_enable_fifo_bdr_cnt_int(dev, LSM6DSO_EN_BIT);
+			} else {
+				return lsm6dso_enable_fifo_bdr_cnt_int(dev, LSM6DSO_DIS_BIT);
+			}
+		}
+#endif
 	}
 #if defined(CONFIG_LSM6DSO_ENABLE_TEMP)
 	else if (trig->chan == SENSOR_CHAN_DIE_TEMP) {
@@ -173,21 +246,39 @@ static void lsm6dso_handle_interrupt(const struct device *dev)
 	struct sensor_trigger drdy_trigger = {
 		.type = SENSOR_TRIG_DATA_READY,
 	};
+#if defined(CONFIG_LSM6DSO_ENABLE_FIFO)
+	struct sensor_trigger bdr_cnt_trigger = {
+		.type = SENSOR_TRIG_LSM6DSO_CNT_BDR,
+	};
+#endif
 	const struct lsm6dso_config *cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 	lsm6dso_status_reg_t status;
+#if defined(CONFIG_LSM6DSO_ENABLE_FIFO)
+	lsm6dso_fifo_status2_t fifo_status2;
+#endif
 
 	while (1) {
 		if (lsm6dso_status_reg_get(ctx, &status) < 0) {
 			LOG_DBG("failed reading status reg");
 			return;
 		}
-
-		if ((status.xlda == 0) && (status.gda == 0)
-#if defined(CONFIG_LSM6DSO_ENABLE_TEMP)
-					&& (status.tda == 0)
+#if defined(CONFIG_LSM6DSO_ENABLE_FIFO)
+		if (lsm6dso_fifo_status_get(ctx, &fifo_status2) < 0) {
+			LOG_DBG("failed reading fifo status2 reg");
+			return;
+		}
 #endif
-					) {
+
+		if (((lsm6dso->handler_drdy_acc == NULL) || (status.xlda == 0))
+					&& ((lsm6dso->handler_drdy_gyr == NULL) || (status.gda == 0))
+#if defined(CONFIG_LSM6DSO_ENABLE_TEMP)
+					&& ((lsm6dso->handler_drdy_temp == NULL) || (status.tda == 0))
+#endif
+#if defined(CONFIG_LSM6DSO_ENABLE_FIFO)
+					&& ((lsm6dso->handler_fifo_bdr_cnt == NULL) || (fifo_status2.counter_bdr_ia == 0))
+#endif
+		) {
 			break;
 		}
 
@@ -199,6 +290,12 @@ static void lsm6dso_handle_interrupt(const struct device *dev)
 			lsm6dso->handler_drdy_gyr(dev, &drdy_trigger);
 		}
 
+#if defined(CONFIG_LSM6DSO_ENABLE_FIFO)
+		if ((fifo_status2.counter_bdr_ia) && (lsm6dso->handler_fifo_bdr_cnt != NULL)) {
+			lsm6dso->handler_fifo_bdr_cnt(dev, &bdr_cnt_trigger);
+		}
+#endif
+
 #if defined(CONFIG_LSM6DSO_ENABLE_TEMP)
 		if ((status.tda) && (lsm6dso->handler_drdy_temp != NULL)) {
 			lsm6dso->handler_drdy_temp(dev, &drdy_trigger);
@@ -206,7 +303,7 @@ static void lsm6dso_handle_interrupt(const struct device *dev)
 #endif
 	}
 
-	gpio_pin_interrupt_configure_dt(&cfg->gpio_drdy,
+	gpio_pin_interrupt_configure_dt(&cfg->gpio_intr,
 					GPIO_INT_EDGE_TO_ACTIVE);
 }
 
@@ -219,7 +316,7 @@ static void lsm6dso_gpio_callback(const struct device *dev,
 
 	ARG_UNUSED(pins);
 
-	gpio_pin_interrupt_configure_dt(&cfg->gpio_drdy, GPIO_INT_DISABLE);
+	gpio_pin_interrupt_configure_dt(&cfg->gpio_intr, GPIO_INT_DISABLE);
 
 #if defined(CONFIG_LSM6DSO_TRIGGER_OWN_THREAD)
 	k_sem_give(&lsm6dso->gpio_sem);
@@ -256,8 +353,8 @@ int lsm6dso_init_interrupt(const struct device *dev)
 	int ret;
 
 	/* setup data ready gpio interrupt (INT1 or INT2) */
-	if (!device_is_ready(cfg->gpio_drdy.port)) {
-		LOG_ERR("Cannot get pointer to drdy_gpio device");
+	if (!device_is_ready(cfg->gpio_intr.port)) {
+		LOG_ERR("Cannot get pointer to interrupt gpio device");
 		return -EINVAL;
 	}
 
@@ -273,7 +370,7 @@ int lsm6dso_init_interrupt(const struct device *dev)
 	lsm6dso->work.handler = lsm6dso_work_cb;
 #endif /* CONFIG_LSM6DSO_TRIGGER_OWN_THREAD */
 
-	ret = gpio_pin_configure_dt(&cfg->gpio_drdy, GPIO_INPUT);
+	ret = gpio_pin_configure_dt(&cfg->gpio_intr, GPIO_INPUT);
 	if (ret < 0) {
 		LOG_DBG("Could not configure gpio");
 		return ret;
@@ -281,9 +378,9 @@ int lsm6dso_init_interrupt(const struct device *dev)
 
 	gpio_init_callback(&lsm6dso->gpio_cb,
 			   lsm6dso_gpio_callback,
-			   BIT(cfg->gpio_drdy.pin));
+			   BIT(cfg->gpio_intr.pin));
 
-	if (gpio_add_callback(cfg->gpio_drdy.port, &lsm6dso->gpio_cb) < 0) {
+	if (gpio_add_callback(cfg->gpio_intr.port, &lsm6dso->gpio_cb) < 0) {
 		LOG_DBG("Could not set gpio callback");
 		return -EIO;
 	}
@@ -294,6 +391,6 @@ int lsm6dso_init_interrupt(const struct device *dev)
 		return -EIO;
 	}
 
-	return gpio_pin_interrupt_configure_dt(&cfg->gpio_drdy,
+	return gpio_pin_interrupt_configure_dt(&cfg->gpio_intr,
 					       GPIO_INT_EDGE_TO_ACTIVE);
 }

--- a/dts/bindings/sensor/st,lsm6dso-common.yaml
+++ b/dts/bindings/sensor/st,lsm6dso-common.yaml
@@ -112,3 +112,53 @@ properties:
         - 8  # 1667Hz
         - 9  # 3333Hz
         - 10 # 6667Hz
+
+    accel-bdr:
+      type: int
+      required: false
+      default: 0
+      description: |
+        Specify the default accel batch data rate expressed in samples per second (Hz).
+        Default is not batched.
+      enum:
+        - 0  # Not batched
+        - 1  # 12.5Hz
+        - 2  # 26Hz
+        - 3  # 52Hz
+        - 4  # 104Hz
+        - 5  # 208Hz
+        - 6  # 417Hz
+        - 7  # 833Hz
+        - 8  # 1667Hz
+        - 9  # 3333Hz
+        - 10 # 6667Hz
+        - 11 # 1.6Hz
+
+    gyro-bdr:
+      type: int
+      required: false
+      default: 0
+      description: |
+        Specify the default gyro batch data rate expressed in samples per second (Hz).
+        Default is not batched.
+      enum:
+        - 0  # Not batched
+        - 1  # 12.5Hz
+        - 2  # 26Hz
+        - 3  # 52Hz
+        - 4  # 104Hz
+        - 5  # 208Hz
+        - 6  # 417Hz
+        - 7  # 833Hz
+        - 8  # 1667Hz
+        - 9  # 3333Hz
+        - 10 # 6667Hz
+        - 11 # 6.5Hz
+
+    batch-cnt-thr:
+      type: int
+      required: false
+      default: 0
+      description: |
+        Specify the default batch count threshold to trigger interrupt.
+        max value is 2047

--- a/include/drivers/sensor/lsm6dso.h
+++ b/include/drivers/sensor/lsm6dso.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022, Linus Reitmayr
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Datasheet:
+ * https://www.st.com/resource/en/datasheet/lsm6dso.pdf
+ */
+
+/**
+ * @file
+ * @brief Extended public API for the lsm6dso driver
+ *
+ * This exposes one attribute for the lsm6dso which can be used for
+ * setting the low pass filter cut-off frequency.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_LSM6DSO_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_LSM6DSO_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <drivers/sensor.h>
+
+/** @brief Sensor specific attributes of LSM6DSO */
+enum sensor_attribute_lsm6dso {
+	/** Sensor CPI for both X and Y axes. */
+	SENSOR_ATTR_LPF_FREQ = SENSOR_ATTR_PRIV_START,
+};
+
+#if defined(CONFIG_LSM6DSO_ENABLE_FIFO)
+enum sensor_trigger_type_lsm6dso {
+	/** Counter batch data rate trigger */
+	SENSOR_TRIG_LSM6DSO_CNT_BDR = SENSOR_TRIG_PRIV_START,
+};
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_LSM6DSO_H_ */


### PR DESCRIPTION
- Add LSM6DSO_ENABLE_FIFO to Kconfig to enable fifo output in prj.conf
- New dts variables for fifo batch mode config:
  - accel and gyro batch data rate: rate of data written to fifo
  - batch count threshold: interrupt triggered when threshold reached
- New public API for lsm6dso sensor specific triggers and attributes:
  - Trigger SENSOR_TRIG_LSM6DSO_CNT_BDR for bdr count threshold reached
- Ability to enable LPF for accel and gyro and configure cut-off
  frequency in devicetree
- Function to fetch all data in fifo:
  - Only handles accel and gyro data with tagged with LSM6DSO_GYRO_NC_TAG
    and LSM6DSO_XL_NC_TAG
  - Called with channel SENSOR_CHAN_ALL if fifo enabled
- Initialise FIFO with optional batch mode:
  - Threshold, accel and gyro batch data rate configured in devicetree
- Rename interrupt GPIO pin to be more generic
- New trigger and handler for fifo bdr count threshold reached:
  - Initialise interrupt on either int1 or 2 line
  - Clear FIFO when trigger gets enabled
  - Use accel or gyro for batch counter based on trigger channel