### PR TITLE
smp: Change IO capabilities to work for RTN and BSN on UCD:

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -313,7 +313,7 @@ static uint8_t get_io_capa(void)
 	if (bt_auth->passkey_entry) {
 		if (IS_ENABLED(CONFIG_BT_FIXED_PASSKEY) &&
 		    fixed_passkey != BT_PASSKEY_INVALID) {
-			return BT_SMP_IO_KEYBOARD_DISPLAY;
+			return BT_SMP_IO_DISPLAY_ONLY;
 		} else {
 			return BT_SMP_IO_KEYBOARD_ONLY;
 		}


### PR DESCRIPTION
- For the RTN the UCD needs to have a passkey_entry to use the fixed key
  while bonding to OCWs
- If passkey_entry and fixed key is enabled the smp module sets IO
  capabilities to keyboard and display, which means a random key
  pairing method is used
- For the BSN bonding we need to use the fixed passkey method, thus the
  IO capabilities need to changed to only support display (which is
  faked by the fixed key config)