### PR TITLE
smp: Fix pairing mechanism for RTN:

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -402,6 +402,11 @@ static uint8_t get_pair_method(struct bt_smp *smp, uint8_t remote_io)
 		return JUST_WORKS;
 	}
 
+	if (remote_io == BT_SMP_IO_DISPLAY_ONLY
+		&& get_io_capa() == BT_SMP_IO_DISPLAY_ONLY) {
+			return PASSKEY_DISPLAY;
+	}
+
 	return gen_method_sc[remote_io][get_io_capa()];
 #else
 	return JUST_WORKS;


### PR DESCRIPTION
- Add a special case for the pairing method with the new UCD IO
  capability combination to keep the pairing mechanism working on the
  RTN